### PR TITLE
update reset

### DIFF
--- a/adafruit_ad569x.py
+++ b/adafruit_ad569x.py
@@ -33,6 +33,7 @@ Implementation Notes
 
 """
 
+import time
 from micropython import const
 from adafruit_bus_device.i2c_device import I2CDevice
 
@@ -190,8 +191,12 @@ class Adafruit_AD569x:
         """
         Soft-reset the AD569x chip.
         """
-        reset_command = 0x8000
+        buffer = bytearray([_WRITE_CONTROL, 0x80, 0x00])
         try:
-            self._send_command(_WRITE_CONTROL, reset_command)
-        except Exception as error:
-            raise Exception(f"Error during reset: {error}") from error
+            with self.i2c_device as i2c:
+                i2c.write(buffer, end=False)
+        except OSError:
+            pass
+            # print(f"Reset may have triggered a NAK, continuing..")
+        # stabilize after reset
+        time.sleep(0.01)


### PR DESCRIPTION
i was able to reproduce https://github.com/adafruit/Adafruit_CircuitPython_AD569x/issues/3. also saw the same behavior that it **_did_** work with other boards (esp32-s3 tft feather and rp2040 feather). i think that the reset() function was raising the error because the DAC was resetting before the command was being acknowledged over I2C (this is noted in the [arduino driver](https://github.com/adafruit/Adafruit_AD569x/blob/6e725d0efbe4010b3971d011c6df82f64d6b0541/Adafruit_AD569x.cpp#L189)). i updated the function to not raise